### PR TITLE
feat: Add Frequency Response Analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - `audio_analyzer`: 音声信号の歪や特性を解析するツール
 - `audio_signal_generator`: 任意波形やテストトーンを生成するためのツール
 - `audio_imd_analyzer`: オーディオ信号の相互変調歪（IMD）を測定するツール (詳細は `audio_imd_analyzer/README.md` を参照)
+- `audio_freq_response_analyzer`: オーディオデバイスの周波数応答（振幅および位相）を測定・プロットするツール (詳細は `audio_freq_response_analyzer/README.md` を参照)
 
 ---
 


### PR DESCRIPTION
This commit introduces the `audio_freq_response_analyzer.py` capability, capable of measuring and plotting the frequency response (amplitude and phase) of audio devices.

Features:
- Sweeps through logarithmically spaced discrete sine tones.
- Plays tones and records the response via a selected audio interface.
- Analyzes each recorded segment for amplitude (dBFS) and phase (degrees).
- Performs phase unwrapping on the collected phase data.
- Generates plots of amplitude vs. frequency and phase vs. frequency using Matplotlib.
- Saves measurement data to a CSV file.
- Provides CLI options for frequency range, steps per octave, amplitude, duration per step, audio device/channel selection, FFT window, and output files.
- Includes unit tests for core logic (frequency generation, segment analysis).
- Comes with a dedicated README in its own directory.

The main project README.md has also been updated to include this new capability. The functionality is organized within the `audio_freq_response_analyzer/` directory.