### PR TITLE
feat: Add CCIF IMD measurement to audio_imd_analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - `audio_analyzer`: 音声信号の歪や特性を解析するツール
 - `audio_signal_generator`: 任意波形やテストトーンを生成するためのツール
-- `audio_imd_analyzer`: オーディオ信号の相互変調歪（IMD）を測定するツール (詳細は `audio_imd_analyzer/README.md` を参照)
+- `audio_imd_analyzer`: オーディオ信号の相互変調歪（IMD）を測定するツール。SMPTE (RP120-1994) および CCIF (ITU-R) 規格をサポートしています。(詳細は `audio_imd_analyzer/README.md` を参照)
 - `audio_freq_response_analyzer`: オーディオデバイスの周波数応答（振幅および位相）を測定・プロットするツール (詳細は `audio_freq_response_analyzer/README.md` を参照)
 
 ---

--- a/audio_imd_analyzer/README.md
+++ b/audio_imd_analyzer/README.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-This Python script, `audio_imd_analyzer.py`, is a command-line tool designed to generate a dual-tone test signal, play it through an audio output device, record it via an input device (typically in a loopback configuration or through a Device Under Test - DUT), and then analyze the recorded audio for Intermodulation Distortion (IMD). The primary analysis method implemented is based on the SMPTE RP120-1994 standard.
+This Python script, `audio_imd_analyzer.py`, is a command-line tool designed to generate a dual-tone test signal, play it through an audio output device, record it via an input device (typically in a loopback configuration or through a Device Under Test - DUT), and then analyze the recorded audio for Intermodulation Distortion (IMD). The script supports two common IMD measurement standards:
+- **SMPTE RP120-1994**: Utilizes a low-frequency tone and a high-frequency tone with a 4:1 amplitude ratio.
+- **CCIF (ITU-R Recommendation BS.559-2, Method 2)**: Employs two closely spaced high-frequency tones of equal amplitude (e.g., 19kHz and 20kHz) to measure distortion products such as the 1kHz difference tone (f2-f1) and third-order products (e.g., 2*f1-f2 at 18kHz and 2*f2-f1 at 21kHz).
 
-The tool allows users to specify various parameters for signal generation, audio device selection, and IMD analysis, providing detailed results including IMD percentage, IMD in dB, and a breakdown of individual intermodulation products.
+The tool allows users to specify various parameters for signal generation, audio device selection, and IMD analysis, providing detailed results including IMD percentage, IMD in dB, and a breakdown of individual intermodulation products according to the selected standard.
 
 ## SMPTE RP120-1994 Standard
 
@@ -14,6 +16,20 @@ The SMPTE RP120-1994 standard is a common method for measuring intermodulation d
 - **Amplitude Ratio**: The amplitude of f1 is typically four times the amplitude of f2 (a 4:1 linear ratio, or +12 dB difference).
 
 IMD is then calculated based on the amplitudes of the sideband frequencies (e.g., f2 ± f1, f2 ± 2*f1) relative to the amplitude of the f2 tone in the recorded signal.
+
+## CCIF (ITU-R) IMD Standard
+
+The CCIF method for measuring intermodulation distortion, often associated with ITU-R Recommendation BS.559-2 (Method 2), uses two high-frequency tones of equal amplitude that are closely spaced.
+- **Test Frequencies (f1, f2)**: Typical frequencies are **19 kHz** and **20 kHz**. Other pairs like 13kHz & 14kHz or 18kHz & 19kHz can also be used. The script defaults to 19kHz and 20kHz when CCIF mode is selected and frequencies are not user-specified.
+- **Amplitude Ratio**: The two tones (f1 and f2) have an equal amplitude (a **1:1 linear ratio**). The script defaults to this ratio for CCIF mode if not specified by the user.
+
+Key distortion products analyzed for CCIF IMD include:
+- **d2 (Second-order difference tone)**: `|f2 - f1|`. For 19kHz and 20kHz tones, this is 1kHz.
+- **d3 (Third-order products)**: 
+    - `2*f1 - f2`. For 19kHz and 20kHz, this is 18kHz.
+    - `2*f2 - f1`. For 19kHz and 20kHz, this is 21kHz.
+
+The IMD percentage and dB value are calculated based on the RMS sum of these distortion products relative to the sum of the amplitudes of the two primary tones (f1 + f2).
 
 ## Dependencies
 
@@ -49,7 +65,8 @@ python audio_imd_analyzer/audio_imd_analyzer.py [OPTIONS]
 | `--output_channel`    | `-oc` | `R`                | Output channel for playback: 'L' (left) or 'R' (right).                                                    |
 | `--input_channel`     | `-ic` | `L`                | Input channel for recording: 'L' (left) or 'R' (right).                                                    |
 | `--window`            |       | `blackmanharris`   | FFT window type for analysis (e.g., `hann`, `hamming`, `blackmanharris`).                                  |
-| `--num_sidebands`     |       | `3`                | Number of sideband pairs (e.g., f2 ± n*f1) to analyze for IMD calculation.                                 |
+| `--num_sidebands`     |       | `3`                | Number of sideband pairs (e.g., f2 ± n*f1) to analyze for SMPTE IMD calculation.                           |
+| `--standard`          | `-std`| `smpte`            | IMD standard to use: `smpte` or `ccif`. If `ccif` is chosen and `--f1`, `--f2`, `--ratio` are not specified, they default to 19kHz, 20kHz, and 1.0 respectively. |
 | `--output_csv`        |       | `None`             | **(Placeholder for future implementation)** Path to save IMD product details as a CSV file.                |
 | `--help`              | `-h`  |                    | Show this help message and exit.                                                                           |
 
@@ -60,19 +77,31 @@ This command generates the standard SMPTE signal, plays it on the right channel 
 ```bash
 python audio_imd_analyzer/audio_imd_analyzer.py --f1 60 --f2 7000 --amplitude -12 --ratio 4 --oc R --ic L
 ```
+
+### Example CCIF Command
+
+This command generates a CCIF signal with f1=19kHz and f2=20kHz (implicitly, as defaults for `--standard ccif`), each at -18dBFS (due to `--amplitude -18` and implicit 1:1 ratio for CCIF), plays it on the right channel, records from the left, and analyzes.
+
+```bash
+python audio_imd_analyzer/audio_imd_analyzer.py --standard ccif --amplitude -18 --oc R --ic L
+```
 If no `--device` ID is provided, the script will list available devices and prompt for a selection.
 
 ## Output Description
 
 The script provides the following output:
 1.  **Device Selection**: If `--device` is not specified, a table of available audio devices is shown, and the user is prompted to select one.
-2.  **Signal Generation Info**: Parameters used for generating the dual-tone signal and the max/min values of the generated signal.
+2.  **Signal Generation Info**: Parameters used for generating the dual-tone signal (reflecting chosen standard and any user overrides) and the max/min values of the generated signal.
 3.  **Playback & Recording Info**: Details of the device and channels used for playback and recording, and confirmation of successful recording with shape and max/min values of the recorded audio.
-4.  **IMD Analysis Results**:
-    *   Parameters used for the analysis (f1, f2, window, number of sidebands).
-    *   The measured amplitude of the reference tone f2 (nominal and actual detected frequency, dBFS, and linear amplitude).
-    *   The overall IMD percentage and IMD in dB.
-    *   A table detailing the detected intermodulation products, including:
+4.  **IMD Analysis Results (common for both standards)**:
+    *   The script first indicates which IMD standard (`SMPTE` or `CCIF`) is being used for analysis.
+    *   Parameters used for the analysis (e.g., f1, f2, window).
+    *   The overall IMD percentage and IMD in dB, calculated according to the selected standard.
+    *   A table detailing the detected intermodulation products. The content and reference for levels in this table depend on the standard:
+
+    **For SMPTE:**
+    *   The measured amplitude of the reference tone f2 (nominal and actual detected frequency, dBFS, and linear amplitude) is displayed.
+    *   The IMD Product Details table includes:
         *   **Order (n)**: The order of the sideband (e.g., 1 for f2 ± f1, 2 for f2 ± 2*f1).
         *   **Type**: '+' for upper sidebands (f2 + n*f1), '-' for lower sidebands (f2 - n*f1).
         *   **Nom. Freq (Hz)**: The nominal (expected) frequency of the IMD product.
@@ -80,9 +109,9 @@ The script provides the following output:
         *   **Amplitude (Lin)**: The linear amplitude of the detected IMD product.
         *   **Level (dBr f2)**: The level of the IMD product in dB relative to the amplitude of the f2 reference tone.
 
-**Example IMD Product Details Table:**
+**Example SMPTE IMD Product Details Table:**
 ```
-                                        IMD Product Details
+                                     SMPTE IMD Product Details
 ┏━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
 ┃ Order (n) ┃ Type   ┃ Nom. Freq (Hz)   ┃ Act. Freq (Hz)   ┃ Amplitude (Lin)   ┃ Level (dBr f2)   ┃
 ┡━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
@@ -92,6 +121,27 @@ The script provides the following output:
 │ 2         │ -      │           6880.0 │           6879.9 │          4.88e-07 │           -68.21 │
 └───────────┴────────┴──────────────────┴──────────────────┴───────────────────┴──────────────────┘
 ```
+
+    **For CCIF:**
+    *   The measured amplitudes of both reference tones, f1 and f2 (nominal and actual detected frequencies, dBFS, and linear amplitudes), are displayed.
+    *   The IMD Product Details table includes:
+        *   **Product Type**: Describes the IMD product (e.g., "d2 (f2-f1)", "d3 (2f1-f2)").
+        *   **Nom. Freq (Hz)**: The nominal (expected) frequency of the IMD product.
+        *   **Act. Freq (Hz)**: The actual frequency at which the peak was detected.
+        *   **Amplitude (Lin)**: The linear amplitude of the detected IMD product.
+        *   **Level (dBr f1+f2)**: The level of the IMD product in dB relative to the sum of the amplitudes of the f1 and f2 reference tones.
+
+**Example CCIF IMD Product Details Table:**
+```
+                                     CCIF IMD Product Details
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+┃ Product Type ┃ Nom. Freq (Hz)   ┃ Act. Freq (Hz)   ┃ Amplitude (Lin)   ┃ Level (dBr f1+f2) ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+│ d2 (f2-f1)   │           1000.0 │            999.8 │          2.50e-05 │            -50.00 │
+│ d3 (2f1-f2)  │          18000.0 │          17999.5 │          1.25e-06 │            -66.02 │
+│ d3 (2f2-f1)  │          21000.0 │          21000.3 │          1.30e-06 │            -65.70 │
+└──────────────┴──────────────────┴──────────────────┴───────────────────┴───────────────────┘
+```
 *(Note: Actual values will vary based on the audio interface and loopback/DUT characteristics.)*
 
 ## Important Notes
@@ -100,4 +150,8 @@ The script provides the following output:
 -   **Audio Interface Quality**: The quality of the audio interface (sound card) used for playback and recording significantly impacts the IMD results. High-quality interfaces with low noise and distortion are crucial for obtaining meaningful measurements. The script itself does not introduce IMD; any measured distortion comes from the audio hardware path.
 -   **Error Handling**: The script includes error handling for device selection, signal generation issues, and audio stream problems. Error messages are printed to `stderr`.
 -   **Amplitude Calibration**: The script operates with digital signal levels (dBFS). For absolute acoustic measurements, calibration of input and output levels would be necessary.
+
+## License
+
+This software is released into the public domain via the Unlicense.
 ```

--- a/audio_imd_analyzer/audio_imd_analyzer.py
+++ b/audio_imd_analyzer/audio_imd_analyzer.py
@@ -223,6 +223,117 @@ def analyze_imd_smpte(recorded_audio, sample_rate, f1, f2, window_name='blackman
         'imd_products_details': imd_products_details
     }
 
+def analyze_imd_ccif(recorded_audio, sample_rate, f1, f2, window_name='blackmanharris'):
+    """
+    Analyzes recorded audio for CCIF (twin-tone) Intermodulation Distortion.
+    f1 and f2 are the nominal frequencies of the two input tones.
+    """
+    N = len(recorded_audio)
+    if N == 0:
+        error_console.print("Cannot analyze empty recorded audio for CCIF.")
+        return None
+
+    try:
+        window_samples = scipy.signal.get_window(window_name, N)
+    except (ValueError, TypeError) as e:
+        error_console.print(f"Invalid FFT window '{window_name}': {e}. Using 'blackmanharris'.")
+        window_name = 'blackmanharris'
+        window_samples = scipy.signal.get_window(window_name, N)
+
+    windowed_signal = recorded_audio * window_samples
+    fft_result = np.fft.rfft(windowed_signal)
+    # Scale FFT magnitude: (2 / sum_of_window_samples) for single-sided spectrum
+    # This scaling gives peak amplitude of sine waves, not RMS.
+    scaled_fft_magnitude = np.abs(fft_result) * (2 / np.sum(window_samples))
+    fft_frequencies = np.fft.rfftfreq(N, d=1/sample_rate)
+
+    # Determine a reasonable search width for f1 and f2, e.g., 1/4 of their difference or min 50Hz
+    f_diff = abs(f2 - f1)
+    search_half_width_f1_f2 = max(50.0, f_diff / 4.0) 
+
+    amp_f1_freq_actual, amp_f1_linear = _find_peak_amplitude_in_band(scaled_fft_magnitude, fft_frequencies, f1, search_half_width_hz=search_half_width_f1_f2)
+    amp_f2_freq_actual, amp_f2_linear = _find_peak_amplitude_in_band(scaled_fft_magnitude, fft_frequencies, f2, search_half_width_hz=search_half_width_f1_f2)
+
+    if amp_f1_linear < 1e-9 or amp_f2_linear < 1e-9:
+        console.print(f"[yellow]Warning: One or both reference tones f1 ({f1:.1f} Hz, amp: {amp_f1_linear:.2e}) "
+                      f"or f2 ({f2:.1f} Hz, amp: {amp_f2_linear:.2e}) are too low for meaningful CCIF IMD analysis.[/yellow]")
+        return {
+            'imd_percentage': 0.0, 'imd_db': -np.inf,
+            'amp_f1_dbfs': 20 * np.log10(amp_f1_linear) if amp_f1_linear > 1e-9 else -np.inf,
+            'amp_f1_linear': amp_f1_linear, 'amp_f1_freq_actual': amp_f1_freq_actual,
+            'amp_f2_dbfs': 20 * np.log10(amp_f2_linear) if amp_f2_linear > 1e-9 else -np.inf,
+            'amp_f2_linear': amp_f2_linear, 'amp_f2_freq_actual': amp_f2_freq_actual,
+            'imd_products_details': []
+        }
+
+    sum_amp_f1_f2 = amp_f1_linear + amp_f2_linear
+    if sum_amp_f1_f2 < 1e-9: # Should be caught by above, but as a safeguard
+        error_console.print("Sum of reference tone amplitudes is too low for CCIF analysis.")
+        # Return structure consistent with low signal warning
+        return {
+            'imd_percentage': 0.0, 'imd_db': -np.inf,
+            'amp_f1_dbfs': 20 * np.log10(amp_f1_linear) if amp_f1_linear > 1e-9 else -np.inf,
+            'amp_f1_linear': amp_f1_linear, 'amp_f1_freq_actual': amp_f1_freq_actual,
+            'amp_f2_dbfs': 20 * np.log10(amp_f2_linear) if amp_f2_linear > 1e-9 else -np.inf,
+            'amp_f2_linear': amp_f2_linear, 'amp_f2_freq_actual': amp_f2_freq_actual,
+            'imd_products_details': []
+        }
+
+
+    imd_products_details = []
+    distortion_products_linear_amps_sq = [] # For RMS sum
+
+    # Difference tone (d2)
+    freq_d2_nominal = abs(f2 - f1)
+    # Search width for d2 can be tighter, e.g. 20Hz, as it's usually well separated
+    actual_d2_freq, amp_d2_linear = _find_peak_amplitude_in_band(scaled_fft_magnitude, fft_frequencies, freq_d2_nominal, search_half_width_hz=20.0)
+    if amp_d2_linear > 1e-12: # Threshold for considering a product significant
+        dbr_sum = 20 * np.log10(amp_d2_linear / sum_amp_f1_f2)
+        imd_products_details.append({
+            'type': "d2 (f2-f1)", 'freq_hz_nominal': freq_d2_nominal,
+            'freq_hz_actual': actual_d2_freq, 'amp_linear': amp_d2_linear, 'amp_dbr_f_sum': dbr_sum
+        })
+        distortion_products_linear_amps_sq.append(amp_d2_linear**2)
+
+    # Third-order product 1 (d3_lower): 2*f1 - f2
+    freq_d3_lower_nominal = 2 * f1 - f2
+    if freq_d3_lower_nominal > 0:
+        actual_d3_lower_freq, amp_d3_lower_linear = _find_peak_amplitude_in_band(scaled_fft_magnitude, fft_frequencies, freq_d3_lower_nominal, search_half_width_hz=20.0)
+        if amp_d3_lower_linear > 1e-12:
+            dbr_sum = 20 * np.log10(amp_d3_lower_linear / sum_amp_f1_f2)
+            imd_products_details.append({
+                'type': "d3 (2f1-f2)", 'freq_hz_nominal': freq_d3_lower_nominal,
+                'freq_hz_actual': actual_d3_lower_freq, 'amp_linear': amp_d3_lower_linear, 'amp_dbr_f_sum': dbr_sum
+            })
+            distortion_products_linear_amps_sq.append(amp_d3_lower_linear**2)
+
+    # Third-order product 2 (d3_upper): 2*f2 - f1
+    freq_d3_upper_nominal = 2 * f2 - f1
+    if freq_d3_upper_nominal > 0: # Should always be true if f1, f2 > 0
+        actual_d3_upper_freq, amp_d3_upper_linear = _find_peak_amplitude_in_band(scaled_fft_magnitude, fft_frequencies, freq_d3_upper_nominal, search_half_width_hz=20.0)
+        if amp_d3_upper_linear > 1e-12:
+            dbr_sum = 20 * np.log10(amp_d3_upper_linear / sum_amp_f1_f2)
+            imd_products_details.append({
+                'type': "d3 (2f2-f1)", 'freq_hz_nominal': freq_d3_upper_nominal,
+                'freq_hz_actual': actual_d3_upper_freq, 'amp_linear': amp_d3_upper_linear, 'amp_dbr_f_sum': dbr_sum
+            })
+            distortion_products_linear_amps_sq.append(amp_d3_upper_linear**2)
+    
+    rms_sum_distortion_products = np.sqrt(np.sum(distortion_products_linear_amps_sq)) if distortion_products_linear_amps_sq else 0.0
+    
+    imd_percentage = (rms_sum_distortion_products / sum_amp_f1_f2) * 100
+    imd_db = 20 * np.log10(rms_sum_distortion_products / sum_amp_f1_f2) if rms_sum_distortion_products > 1e-9 else -np.inf # Avoid log(0)
+
+    amp_f1_dbfs = 20 * np.log10(amp_f1_linear) if amp_f1_linear > 1e-9 else -np.inf
+    amp_f2_dbfs = 20 * np.log10(amp_f2_linear) if amp_f2_linear > 1e-9 else -np.inf
+
+    return {
+        'imd_percentage': imd_percentage, 'imd_db': imd_db,
+        'amp_f1_dbfs': amp_f1_dbfs, 'amp_f1_linear': amp_f1_linear, 'amp_f1_freq_actual': amp_f1_freq_actual,
+        'amp_f2_dbfs': amp_f2_dbfs, 'amp_f2_linear': amp_f2_linear, 'amp_f2_freq_actual': amp_f2_freq_actual,
+        'imd_products_details': imd_products_details
+    }
+
 def main():
     parser = argparse.ArgumentParser(description="Generate, play, record, and analyze a dual-tone signal for IMD testing.")
     # Group arguments for clarity
@@ -241,8 +352,31 @@ def main():
 
     analysis_group = parser.add_argument_group('Analysis Parameters')
     analysis_group.add_argument("--window", type=str, default='blackmanharris', help="FFT window type")
-    analysis_group.add_argument("--num_sidebands", type=int, default=3, help="Number of sideband pairs for IMD")
+    analysis_group.add_argument("--num_sidebands", type=int, default=3, help="Number of sideband pairs for SMPTE IMD")
+    analysis_group.add_argument("--standard", "-std", type=str, default='smpte', choices=['smpte', 'ccif'], help="IMD standard to use (smpte or ccif)")
     args = parser.parse_args()
+
+    # --- Adjust defaults for CCIF ---
+    if args.standard == 'ccif':
+        # Check if f1, f2, and ratio were provided by the user (not default)
+        # Default values are specified in add_argument
+        user_provided_f1 = args.f1 != parser.get_default("f1")
+        user_provided_f2 = args.f2 != parser.get_default("f2")
+        user_provided_ratio = args.ratio != parser.get_default("ratio")
+
+        if not user_provided_f1 and not user_provided_f2:
+            args.f1 = 19000.0
+            args.f2 = 20000.0
+            console.print(f"[yellow]CCIF standard selected. Defaulting f1={args.f1}Hz, f2={args.f2}Hz.[/yellow]")
+        elif user_provided_f1 != user_provided_f2: # if user only provided one, it's ambiguous for CCIF
+            error_console.print("For CCIF, please provide both --f1 and --f2, or neither to use defaults.")
+            sys.exit(1)
+        
+        if not user_provided_ratio:
+            args.ratio = 1.0
+            console.print(f"[yellow]CCIF standard selected. Defaulting --ratio={args.ratio}.[/yellow]")
+        elif args.ratio != 1.0:
+            console.print(f"[yellow]Warning: CCIF standard typically uses a 1:1 ratio. User specified --ratio={args.ratio}.[/yellow]")
 
     # --- Device Selection and Validation ---
     if args.device is None:
@@ -320,44 +454,91 @@ def main():
     console.print(f"  Audio recorded. Shape: {recorded_audio.shape}, Max/Min: {np.max(recorded_audio):.4f} / {np.min(recorded_audio):.4f}")
 
     # --- IMD Analysis ---
-    console.print(f"\n[green]Analyzing recorded audio for IMD...[/green]")
-    console.print(f"  Analysis Parameters: f1={args.f1}Hz, f2={args.f2}Hz, Window={args.window}, Sidebands={args.num_sidebands}")
-    try:
-        imd_results = analyze_imd_smpte(
-            recorded_audio, args.sample_rate, args.f1, args.f2, 
-            window_name=args.window, num_sideband_pairs=args.num_sidebands
-        )
-    except Exception as e: # Catch-all for unexpected analysis errors
-        error_console.print(f"An unexpected error occurred during IMD analysis: {e}")
+    console.print(f"\n[green]Analyzing recorded audio for IMD ({args.standard.upper()})...[/green]")
+    
+    imd_results = None
+    if args.standard == 'smpte':
+        console.print(f"  Analysis Parameters (SMPTE): f1={args.f1}Hz, f2={args.f2}Hz, Window={args.window}, Sidebands={args.num_sidebands}")
+        try:
+            imd_results = analyze_imd_smpte(
+                recorded_audio, args.sample_rate, args.f1, args.f2, 
+                window_name=args.window, num_sideband_pairs=args.num_sidebands
+            )
+        except Exception as e:
+            error_console.print(f"An unexpected error occurred during SMPTE IMD analysis: {e}")
+            sys.exit(1)
+
+        if imd_results:
+            f2_nominal = args.f2
+            f2_actual = imd_results['amp_f2_freq_actual']
+            console.print(f"  Reference f2 (Nominal: {f2_nominal:.1f}Hz, Actual: {f2_actual:.1f}Hz): {imd_results['amp_f2_dbfs']:.2f} dBFS ({imd_results['amp_f2_linear']:.4f} linear)")
+            console.print(f"  IMD (SMPTE, {args.num_sidebands} pairs): [bold cyan]{imd_results['imd_percentage']:.4f} %[/bold cyan] / [bold cyan]{imd_results['imd_db']:.2f} dB[/bold cyan]")
+
+            if imd_results['imd_products_details']:
+                table = Table(title="SMPTE IMD Product Details")
+                table.add_column("Order (n)", style="cyan")
+                table.add_column("Type", style="cyan")
+                table.add_column("Nom. Freq (Hz)", style="magenta", justify="right")
+                table.add_column("Act. Freq (Hz)", style="magenta", justify="right")
+                table.add_column("Amplitude (Lin)", style="green", justify="right")
+                table.add_column("Level (dBr f2)", style="yellow", justify="right")
+
+                for p in imd_results['imd_products_details']:
+                    table.add_row(str(p['order_n']), p['type'], f"{p['freq_hz_nominal']:.1f}", 
+                                  f"{p['freq_hz_actual']:.1f}", f"{p['amp_linear']:.2e}", f"{p['amp_dbr_f2']:.2f}")
+                console.print(table)
+            else:
+                console.print("  No significant SMPTE IMD products found above threshold.")
+        else: # Should not happen if analyze_imd_smpte always returns a dict or raises error
+            error_console.print("SMPTE IMD analysis returned no results.")
+            sys.exit(1)
+
+    elif args.standard == 'ccif':
+        console.print(f"  Analysis Parameters (CCIF): f1={args.f1}Hz, f2={args.f2}Hz, Window={args.window}")
+        try:
+            imd_results = analyze_imd_ccif(
+                recorded_audio, args.sample_rate, args.f1, args.f2, 
+                window_name=args.window
+            )
+        except Exception as e:
+            error_console.print(f"An unexpected error occurred during CCIF IMD analysis: {e}")
+            sys.exit(1)
+
+        if imd_results:
+            f1_nom, f1_act = args.f1, imd_results['amp_f1_freq_actual']
+            f2_nom, f2_act = args.f2, imd_results['amp_f2_freq_actual']
+            console.print(f"  Reference f1 (Nom: {f1_nom:.1f}Hz, Act: {f1_act:.1f}Hz): {imd_results['amp_f1_dbfs']:.2f} dBFS ({imd_results['amp_f1_linear']:.4f} lin)")
+            console.print(f"  Reference f2 (Nom: {f2_nom:.1f}Hz, Act: {f2_act:.1f}Hz): {imd_results['amp_f2_dbfs']:.2f} dBFS ({imd_results['amp_f2_linear']:.4f} lin)")
+            console.print(f"  IMD (CCIF): [bold cyan]{imd_results['imd_percentage']:.4f} %[/bold cyan] / [bold cyan]{imd_results['imd_db']:.2f} dB[/bold cyan]")
+
+            if imd_results['imd_products_details']:
+                table = Table(title="CCIF IMD Product Details")
+                table.add_column("Product Type", style="cyan", width=12)
+                table.add_column("Nom. Freq (Hz)", style="magenta", justify="right")
+                table.add_column("Act. Freq (Hz)", style="magenta", justify="right")
+                table.add_column("Amplitude (Lin)", style="green", justify="right")
+                table.add_column("Level (dBr f1+f2)", style="yellow", justify="right")
+
+                for p in imd_results['imd_products_details']:
+                    table.add_row(p['type'], f"{p['freq_hz_nominal']:.1f}", 
+                                  f"{p['freq_hz_actual']:.1f}", f"{p['amp_linear']:.2e}", f"{p['amp_dbr_f_sum']:.2f}")
+                console.print(table)
+            else:
+                console.print("  No significant CCIF IMD products found above threshold.")
+        else: # Should not happen if analyze_imd_ccif always returns a dict or raises error
+            error_console.print("CCIF IMD analysis returned no results.")
+            sys.exit(1)
+    
+    else: # Should be caught by argparse choices
+        error_console.print(f"Unknown IMD standard: {args.standard}")
         sys.exit(1)
 
-    if imd_results:
-        f2_nominal = args.f2
-        f2_actual = imd_results['amp_f2_freq_actual']
-        console.print(f"  Reference f2 (Nominal: {f2_nominal:.1f}Hz, Actual: {f2_actual:.1f}Hz): {imd_results['amp_f2_dbfs']:.2f} dBFS ({imd_results['amp_f2_linear']:.4f} linear)")
-        console.print(f"  IMD (SMPTE, {args.num_sidebands} pairs): [bold cyan]{imd_results['imd_percentage']:.4f} %[/bold cyan] / [bold cyan]{imd_results['imd_db']:.2f} dB[/bold cyan]")
-
-        if imd_results['imd_products_details']:
-            table = Table(title="IMD Product Details")
-            table.add_column("Order (n)", style="cyan")
-            table.add_column("Type", style="cyan")
-            table.add_column("Nom. Freq (Hz)", style="magenta", justify="right")
-            table.add_column("Act. Freq (Hz)", style="magenta", justify="right")
-            table.add_column("Amplitude (Lin)", style="green", justify="right")
-            table.add_column("Level (dBr f2)", style="yellow", justify="right")
-
-            for p in imd_results['imd_products_details']:
-                table.add_row(str(p['order_n']), p['type'], f"{p['freq_hz_nominal']:.1f}", 
-                              f"{p['freq_hz_actual']:.1f}", f"{p['amp_linear']:.2e}", f"{p['amp_dbr_f2']:.2f}")
-            console.print(table)
-        else:
-            console.print("  No significant IMD products found above threshold.")
-        console.print("\n[green]IMD analysis complete.[/green]")
-    else:
-        # This case might be hit if analyze_imd_smpte returns None (e.g. empty audio passed, though main guards this)
-        # or if amp_f2_linear was too low but didn't cause an exception.
+    if imd_results: # General success message if any analysis was done
+        console.print(f"\n[green]IMD analysis ({args.standard.upper()}) complete.[/green]")
+    else: # Fallback, though specific errors should have exited earlier
         error_console.print("IMD analysis could not be performed or returned no meaningful results.")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Adds support for CCIF (ITU-R) Intermodulation Distortion analysis to the existing `audio_imd_analyzer.py` script.

Key changes:
- Introduces a `--standard` CLI option to choose between `smpte` (default) and `ccif`.
- When `ccif` is selected, defaults are set for typical CCIF frequencies (19kHz and 20kHz) and a 1:1 amplitude ratio.
- Implements a new analysis function `analyze_imd_ccif` that identifies and quantifies key CCIF distortion products:
    - d2 (difference tone): f2 - f1
    - d3 (third-order products): 2*f1 - f2 and 2*f2 - f1
- CCIF IMD results are reported as a percentage and in dB, relative to the sum of the amplitudes of the two primary tones.
- Unit tests for the new CCIF functionality have been added to `test_audio_imd_analyzer.py`, covering clean signals, signals with known products, and low-level signal handling.
- Documentation (`audio_imd_analyzer/README.md` and the main `README.md`) has been updated to reflect these new capabilities, including usage instructions and example outputs for CCIF mode.
- Unlicense information has been added to the READMEs.