### PR TITLE
feat: Add audio_crosstalk_analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - `audio_signal_generator`: 任意波形やテストトーンを生成するためのツール
 - `audio_imd_analyzer`: オーディオ信号の相互変調歪（IMD）を測定するツール。SMPTE (RP120-1994) および CCIF (ITU-R) 規格をサポートしています。(詳細は `audio_imd_analyzer/README.md` を参照)
 - `audio_freq_response_analyzer`: オーディオデバイスの周波数応答（振幅および位相）を測定・プロットするツール (詳細は `audio_freq_response_analyzer/README.md` を参照)
+- `audio_crosstalk_analyzer`: チャンネル間のオーディオクロストーク（信号漏れ）を測定するツール。(詳細は `audio_crosstalk_analyzer/README.md` を参照)
 
 ---
 

--- a/audio_crosstalk_analyzer/README.md
+++ b/audio_crosstalk_analyzer/README.md
@@ -1,0 +1,129 @@
+# Audio Crosstalk Analyzer
+
+## Overview
+
+The `audio_crosstalk_analyzer.py` script is a command-line tool designed to measure audio crosstalk between channels of an audio device. Crosstalk, also known as channel separation, is the undesired leakage of a signal from one channel into another. This tool plays a test signal (a sine wave) on a specified output channel and simultaneously records from multiple input channels. It then analyzes the recorded signals to determine the level of the test frequency on the driven (reference) input channel and its leakage into other (undriven) input channels.
+
+This tool can be useful for:
+-   Testing the performance of audio interfaces (sound cards).
+-   Evaluating the quality of audio cables and connectors.
+-   Assessing the electrical isolation between channels in a device under test (DUT).
+
+## Features
+
+-   **Test Modes**: Supports both single frequency tests and frequency sweep tests.
+-   **Adjustable Signal Parameters**: Users can define the frequency (for single mode), frequency range and density (for sweep mode), and amplitude (dBFS) of the test signal.
+-   **Flexible Channel Selection**: Allows specification of the output channel and multiple input channels for recording. The first specified input channel serves as the reference (driven channel).
+-   **Informative Console Output**: Results are displayed in a clear, tabular format in the console using Rich.
+-   **CSV Export**: Test results can be saved to a CSV file for further analysis or record-keeping.
+-   **Plot Generation**: For frequency sweep tests, the script can generate and save a plot of crosstalk (dB) versus frequency (logarithmic scale) using Matplotlib. Plot display can also be suppressed.
+
+## Dependencies
+
+The script requires Python 3.8+ and the following Python libraries:
+-   **NumPy**: For numerical operations, especially array manipulation and FFT.
+-   **SoundDevice**: For audio playback and recording via PortAudio.
+-   **SciPy**: For signal processing functions, particularly FFT windowing (`scipy.signal.get_window`).
+-   **Rich**: For enhanced terminal output, including tables and styled text.
+-   **Matplotlib**: For generating plots of crosstalk versus frequency (used in sweep mode).
+
+These dependencies can be installed using pip:
+```bash
+pip install numpy sounddevice scipy rich matplotlib
+```
+
+## Usage
+
+The script is run from the command line:
+```bash
+python audio_crosstalk_analyzer/audio_crosstalk_analyzer.py [OPTIONS]
+```
+
+## Main Options
+
+| Option                      | Alias | Default Value    | Description                                                                                                                               |
+|-----------------------------|-------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `--frequency HZ`            |       | `1000.0`         | Frequency for single mode test (Hz). Must be positive.                                                                                    |
+| `--sweep`                   |       | `False`          | Enable sweep mode. Overrides `--frequency`.                                                                                               |
+| `--start_freq HZ`           |       | `20.0`           | Start frequency for sweep mode (Hz). Must be positive.                                                                                    |
+| `--end_freq HZ`             |       | `20000.0`        | End frequency for sweep mode (Hz). Must be positive.                                                                                      |
+| `--points_per_octave N`     | `-ppo`| `3`              | Number of test points per octave in sweep mode. Must be positive.                                                                         |
+| `--amplitude DBFS`          |       | `-12.0`          | Amplitude of the test signal (dBFS). Must be <= 0.                                                                                        |
+| `--device ID`               |       | Prompts user     | Integer ID of the audio device for playback and recording. If not provided, a list of available devices will be shown for selection.      |
+| `--sample_rate HZ`          |       | `48000`          | Sampling rate in Hz for signal generation, playback, and recording.                                                                       |
+| `--output_channel CH_SPEC`  | `-oc` | `L`              | Output channel for test signal (e.g., 'L', 'R', or numeric 0-based index '0', '1', ...).                                                  |
+| `--input_channels CH_SPEC [...]` | `-ic` | **Required**   | List of input channels to record (e.g., 'L' 'R' or '0' '1' ...). The first channel is the reference for crosstalk calculation (i.e., the channel receiving the direct signal or loopback of the output channel). All specified input channels must be unique. At least two must be specified. |
+| `--window WINDOW_TYPE`      |       | `hann`           | FFT window type for analysis (e.g., `hann`, `blackmanharris`).                                                                              |
+| `--duration_per_step SECS`  |       | `0.5`            | Duration of tone generation and recording for each frequency step (seconds). Must be positive.                                            |
+| `--output_csv FILENAME.csv` |       | `None`           | Path to save results in CSV format (e.g., `results.csv`).                                                                                 |
+| `--output_plot FILENAME.png`|       | `None`           | Path to save crosstalk plot as an image (e.g., `plot.png`). Plot is generated for sweep mode only.                                        |
+| `--no_plot_display`         |       | `False`          | Suppress interactive display of the plot. The plot will still be saved if `--output_plot` is specified.                                     |
+| `--help`                    | `-h`  |                  | Show this help message and exit.                                                                                                          |
+
+*CH_SPEC refers to a channel specifier, which can be 'L' (left), 'R' (right), or a numeric 0-based index (e.g., '0', '1').*
+
+## Example Commands
+
+### Single Frequency Test
+
+This command performs a crosstalk test at 1000 Hz. The test signal at -12 dBFS is played on the Left output channel of device 0. The script records from the Left input channel (as reference) and the Right input channel (as undriven) of device 0.
+
+```bash
+python audio_crosstalk_analyzer/audio_crosstalk_analyzer.py --frequency 1000 --amplitude -12 --output_channel L --input_channels L R --device 0
+```
+
+### Frequency Sweep Test with CSV and Plot Output
+
+This command performs a frequency sweep from 20 Hz to 20000 Hz with 6 points per octave. The test signal is -12 dBFS, played on output channel 0 of device 0. Input channels 0 (reference) and 1 (undriven) are recorded. Results are saved to `crosstalk_results.csv` and a plot is saved to `crosstalk_plot.png`.
+
+```bash
+python audio_crosstalk_analyzer/audio_crosstalk_analyzer.py --sweep --start_freq 20 --end_freq 20000 --points_per_octave 6 --amplitude -12 --output_channel 0 --input_channels 0 1 --output_csv crosstalk_results.csv --output_plot crosstalk_plot.png --device 0
+```
+
+## Output Description
+
+### Console Output
+
+The script first prints details about the selected device and test parameters. During the test, it shows the progress for each frequency. Finally, it displays a summary table of the results. For each frequency tested:
+-   **Freq (Hz)**: The nominal frequency of the test tone.
+-   **Ref Ch ('X') Lvl (dBFS)**: The measured level of the test tone on the reference input channel (specified as the first channel in `--input_channels`). 'X' is the channel specifier.
+-   **Ch 'Y' Lvl (dBFS)**: The measured level of the test tone on an undriven input channel 'Y'.
+-   **Ch 'Y' Crosstalk (dB)**: The calculated crosstalk from the output channel to the undriven input channel 'Y', relative to the level measured on the reference input channel. More negative values indicate better isolation (less crosstalk).
+
+Example table snippet:
+```
+                             Crosstalk Measurement Summary (Output Ch: 'L')
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Freq (Hz)    ┃ Ref Ch ('L') Lvl (dBFS)              ┃ Ch 'R' Lvl (dBFS)                    ┃ Ch 'R' Crosstalk (dB)                   ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│      20.00   │                             -12.05   │                             -75.50   │                                  -63.45   │
+│      25.19   │                             -12.03   │                             -78.12   │                                  -66.09   │
+│      ...     │                                ...   │                                ...   │                                     ...   │
+└──────────────┴──────────────────────────────────────┴──────────────────────────────────────┴─────────────────────────────────────────┘
+```
+
+### CSV File
+
+If `--output_csv` is specified, a CSV file is generated with columns corresponding to the console output table, allowing for easy import into spreadsheet software or other analysis tools.
+
+### Plot Image
+
+If `--output_plot` is specified (and the test is in sweep mode), an image file (e.g., PNG) is generated. The plot shows:
+-   **X-axis**: Frequency (Hz) on a logarithmic scale.
+-   **Y-axis**: Crosstalk (dB).
+-   Each line on the plot represents the crosstalk from the driven output channel to one of the specified undriven input channels across the frequency range. A legend identifies each line.
+
+## Important Notes
+
+-   **Loopback Configuration**: For accurate measurement of an audio interface's own crosstalk or for testing a Device Under Test (DUT), a proper loopback configuration is essential.
+    -   **Interface Self-Test**: Connect a cable from the specified output channel (e.g., Line Out L) directly to the reference input channel (e.g., Line In L). Connect another cable from the same output channel to the undriven input channel you wish to measure crosstalk *into* (e.g., Line In R). This is not standard; typically, you play on one output, measure its loopback on the corresponding input, and measure the leakage on *other* inputs that are *not* directly fed.
+    -   **Corrected Loopback for Typical Crosstalk**: Play signal on Output L. Input L (reference) should be connected to Output L. Input R (undriven) should be terminated appropriately (e.g., with its characteristic impedance or left open, depending on test standard, though this script assumes it's just another input of the interface). The script measures signal on Input L and Input R. Crosstalk is then Input R level relative to Input L level.
+    -   **DUT Testing**: Route the signal from the interface's output channel, through the DUT, and then into the reference and undriven input channels of the interface.
+-   **Audio Interface Quality**: The measured crosstalk will be limited by the performance of the audio interface itself (its own internal crosstalk and noise floor). Using a high-quality interface is crucial for measuring low levels of crosstalk accurately.
+-   **Signal Levels**: Choose the test signal `--amplitude` carefully. It should be high enough to be well above the noise floor but low enough to avoid clipping the output stage of the playback device or the input stage of the recording device/DUT. Check the interface's specifications and use its level meters if available.
+-   **Grounding and Shielding**: Ensure proper grounding and use shielded cables to minimize external interference, which can be misinterpreted as crosstalk.
+
+## License
+
+This software is released into the public domain via the Unlicense. You are free to use, modify, and distribute the code as you see fit. For more details, see <http://unlicense.org/>.
+```

--- a/audio_crosstalk_analyzer/audio_crosstalk_analyzer.py
+++ b/audio_crosstalk_analyzer/audio_crosstalk_analyzer.py
@@ -1,0 +1,553 @@
+import argparse
+import sys
+import numpy as np
+import sounddevice as sd
+import scipy.signal
+from rich.console import Console
+from rich.table import Table
+from rich.prompt import Prompt
+import math
+import csv
+import matplotlib.pyplot as plt
+
+# Initialize consoles
+console = Console()
+error_console = Console(stderr=True, style="bold red")
+
+# --- Helper Functions ---
+
+def dbfs_to_linear(dbfs):
+    """Converts dBFS to linear amplitude."""
+    return 10**(dbfs / 20)
+
+def linear_to_dbfs(linear_amp):
+    """Converts linear amplitude to dBFS. Handles -np.inf for 0 or negative input."""
+    if linear_amp <= 1e-12: # Treat very small numbers as effectively zero / noise floor
+        return -np.inf
+    return 20 * math.log10(linear_amp)
+
+def _find_peak_amplitude_in_band(fft_magnitudes, fft_frequencies, target_freq, search_half_width_hz=20.0):
+    """
+    Finds the peak amplitude and actual frequency of a target frequency within a specified band in an FFT spectrum.
+    """
+    min_freq = target_freq - search_half_width_hz
+    max_freq = target_freq + search_half_width_hz
+    
+    valid_indices = np.where((fft_frequencies >= min_freq) & (fft_frequencies <= max_freq))[0]
+
+    if not valid_indices.size:
+        # This might happen if the signal is extremely weak or absent in the band.
+        return target_freq, 0.0  # Return nominal target_freq and 0 amplitude
+
+    band_magnitudes = fft_magnitudes[valid_indices]
+    peak_index_in_band = np.argmax(band_magnitudes)
+    peak_abs_index = valid_indices[peak_index_in_band]
+    
+    return fft_frequencies[peak_abs_index], fft_magnitudes[peak_abs_index]
+
+
+def channel_spec_to_index(spec, device_channels, channel_type="input"):
+    """
+    Converts channel specifier ('L', 'R', or numeric string) to a 0-based integer index.
+    Validates against the number of available channels on the device.
+    """
+    try:
+        if isinstance(spec, int): 
+            idx = spec
+        elif spec.upper() == 'L':
+            idx = 0
+        elif spec.upper() == 'R':
+            if device_channels < 2:
+                error_console.print(f"Error: Channel 'R' selected for {channel_type}, but device only has {device_channels} channel(s).")
+                return None
+            idx = 1
+        else: 
+            parsed_idx = int(spec)
+            idx = parsed_idx 
+            if not (0 <= idx < device_channels):
+                 error_console.print(f"Error: Numeric {channel_type} channel index {idx} (from spec '{spec}') is out of range for device with {device_channels} channels (0 to {device_channels-1}).")
+                 return None
+        
+        if not (0 <= idx < device_channels): 
+            error_console.print(f"Error: {channel_type.capitalize()} channel index {idx} (derived from spec '{spec}') is out of range for device with {device_channels} channels.")
+            return None
+        return idx
+    except ValueError:
+        error_console.print(f"Error: Invalid {channel_type} channel specifier '{spec}'. Use 'L', 'R', or a numeric 0-based index (e.g., '0', '1').")
+        return None
+
+
+def select_device():
+    """Allows the user to select an audio device for both input and output. Exits if no devices found or error."""
+    try:
+        devices = sd.query_devices()
+    except sd.PortAudioError as e:
+        error_console.print(f"Error querying audio devices: {e}")
+        sys.exit(1)
+        
+    if not devices:
+        error_console.print("No audio devices found.")
+        sys.exit(1)
+
+    table = Table(title="Available Audio Devices")
+    table.add_column("ID", style="cyan")
+    table.add_column("Name", style="magenta")
+    table.add_column("Max Input Ch", style="green")
+    table.add_column("Max Output Ch", style="yellow")
+    table.add_column("Default SR", style="blue")
+
+    suitable_devices = []
+    for i, device in enumerate(devices):
+        table.add_row(
+            str(i),
+            device['name'],
+            str(device['max_input_channels']),
+            str(device['max_output_channels']),
+            str(device['default_samplerate'])
+        )
+        if device['max_input_channels'] > 0 and device['max_output_channels'] > 0:
+            suitable_devices.append(i)
+            
+    console.print(table)
+    
+    if not suitable_devices:
+        error_console.print("No devices found with both input and output capabilities suitable for crosstalk test.")
+        sys.exit(1)
+
+    while True:
+        try:
+            device_id_str = Prompt.ask("Select device ID for playback and recording")
+            device_id = int(device_id_str)
+            if 0 <= device_id < len(devices):
+                if devices[device_id]['max_output_channels'] == 0:
+                    error_console.print(f"Device ID {device_id} ({devices[device_id]['name']}) has no output channels. Please select another.")
+                    continue
+                if devices[device_id]['max_input_channels'] == 0:
+                    error_console.print(f"Device ID {device_id} ({devices[device_id]['name']}) has no input channels. Please select another.")
+                    continue
+                console.print(f"Selected device: ID {device_id} - {devices[device_id]['name']}")
+                return device_id
+            else:
+                error_console.print(f"Invalid ID. Please choose from the list (0 to {len(devices) - 1}).")
+        except ValueError:
+            error_console.print("Invalid input. Please enter a number.")
+        except Exception as e:
+            error_console.print(f"An unexpected error occurred during device selection: {e}")
+            sys.exit(1)
+
+
+def generate_sine_wave(frequency, amplitude_dbfs, duration, sample_rate):
+    """Generates a sine wave NumPy array."""
+    amplitude_linear = dbfs_to_linear(amplitude_dbfs)
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    wave = amplitude_linear * np.sin(2 * np.pi * frequency * t)
+    return np.clip(wave, -1.0, 1.0)
+
+
+def play_and_record_multi_ch(signal_to_play, sample_rate, play_device_idx, 
+                             output_channel_device_idx, input_channel_device_indices, 
+                             duration_seconds, device_info_obj):
+    """
+    Plays a mono signal on a specific output channel and records from multiple input channels.
+    """
+    device_max_output_ch = device_info_obj['max_output_channels']
+
+    output_buffer = np.zeros((len(signal_to_play), device_max_output_ch), dtype=signal_to_play.dtype)
+    if not (0 <= output_channel_device_idx < device_max_output_ch): 
+        error_console.print(f"Internal Error: Output channel index {output_channel_device_idx} invalid for device with {device_max_output_ch} output channels.")
+        return None
+    output_buffer[:, output_channel_device_idx] = signal_to_play
+
+    playrec_input_mapping = [idx + 1 for idx in input_channel_device_indices] 
+    
+    try:
+        recorded_audio = sd.playrec(output_buffer, 
+                                    samplerate=sample_rate, 
+                                    channels=output_buffer.shape[1], 
+                                    input_mapping=playrec_input_mapping,
+                                    device=play_device_idx, 
+                                    blocking=True)
+        return recorded_audio
+    except sd.PortAudioError as e:
+        error_console.print(f"Audio I/O error during playrec for device {play_device_idx} (SR: {sample_rate}, OutCh: {output_channel_device_idx}, InMap: {playrec_input_mapping}): {e}")
+        return None
+    except Exception as e:
+        error_console.print(f"Unexpected error during playrec for device {play_device_idx}: {e}")
+        return None
+
+
+def analyze_recorded_channels(recorded_data_multi_ch, sample_rate, target_frequency, window_name):
+    """
+    Analyzes each channel in the recorded data for the amplitude of the target frequency.
+    Returns a list of dicts: {'nominal_freq', 'actual_freq', 'amplitude_linear'} for each channel.
+    """
+    if recorded_data_multi_ch is None or recorded_data_multi_ch.ndim == 0 :
+        return [] 
+    
+    if recorded_data_multi_ch.ndim == 1: 
+        recorded_data_multi_ch = recorded_data_multi_ch[:, np.newaxis]
+
+    num_channels_recorded = recorded_data_multi_ch.shape[1]
+    N = recorded_data_multi_ch.shape[0]
+    results = []
+
+    if N == 0:
+        return [{'nominal_freq': target_frequency, 'actual_freq': target_frequency, 'amplitude_linear': 0.0}] * num_channels_recorded if num_channels_recorded > 0 else []
+
+    try:
+        window_samples = scipy.signal.get_window(window_name, N)
+    except (ValueError, TypeError) as e:
+        error_console.print(f"Invalid FFT window '{window_name}': {e}. Using 'hann'.")
+        window_name = 'hann'
+        window_samples = scipy.signal.get_window(window_name, N)
+    
+    fft_frequencies = np.fft.rfftfreq(N, d=1/sample_rate)
+
+    for i in range(num_channels_recorded):
+        channel_data = recorded_data_multi_ch[:, i]
+        windowed_signal = channel_data * window_samples
+        fft_result = np.fft.rfft(windowed_signal)
+        
+        scaled_fft_magnitude = np.abs(fft_result) * (2 / np.sum(window_samples))
+        
+        actual_freq, linear_amp = _find_peak_amplitude_in_band(scaled_fft_magnitude, fft_frequencies, target_frequency)
+        results.append({'nominal_freq': target_frequency, 'actual_freq': actual_freq, 'amplitude_linear': linear_amp})
+    
+    return results
+
+
+# --- Main Function ---
+def main():
+    parser = argparse.ArgumentParser(description="Audio Crosstalk Analyzer: Measures crosstalk between audio channels by playing a tone on one output channel and measuring the signal level on specified input channels.")
+
+    mode_group = parser.add_argument_group('Mode Selection')
+    mode_group.add_argument("--frequency", type=float, default=1000.0, help="Frequency for single mode test (Hz). Default: 1000.0. Must be positive.")
+    mode_group.add_argument("--sweep", action='store_true', help="Enable sweep mode. Overrides --frequency.")
+    mode_group.add_argument("--start_freq", type=float, default=20.0, help="Start frequency for sweep mode (Hz). Default: 20.0. Must be positive.")
+    mode_group.add_argument("--end_freq", type=float, default=20000.0, help="End frequency for sweep mode (Hz). Default: 20000.0. Must be positive.")
+    mode_group.add_argument("--points_per_octave", "-ppo", type=int, default=3, help="Number of test points per octave in sweep mode. Default: 3. Must be positive.")
+
+    signal_group = parser.add_argument_group('Signal Parameters')
+    signal_group.add_argument("--amplitude", type=float, default=-12.0, help="Amplitude of the test signal (dBFS). Default: -12.0. Must be <= 0.")
+    
+    device_group = parser.add_argument_group('Audio Device and Channel Parameters')
+    device_group.add_argument("--device", type=int, help="Audio device ID for playback and recording. Prompts if not provided.")
+    device_group.add_argument("--sample_rate", type=int, default=48000, help="Sampling rate (Hz). Default: 48000")
+    device_group.add_argument("--output_channel", "-oc", type=str, default='L', help="Output channel for test signal (e.g., 'L', 'R', or numeric 0-based index '0', '1', ...). Default: 'L'")
+    device_group.add_argument("--input_channels", "-ic", type=str, nargs='+', required=True, help="List of input channels to record (e.g., 'L' 'R' or '0' '1' ...). First channel is the reference for crosstalk calculation (i.e., the channel receiving the direct signal or loopback of output_channel). All specified input channels must be unique.")
+
+    analysis_group = parser.add_argument_group('Analysis Parameters')
+    analysis_group.add_argument("--window", type=str, default='hann', help="FFT window type (e.g., hann, blackmanharris). Default: 'hann'")
+    analysis_group.add_argument("--duration_per_step", type=float, default=0.5, help="Duration of tone and recording for each frequency step (seconds). Default: 0.5. Must be positive.")
+
+    output_group = parser.add_argument_group('Output Options')
+    output_group.add_argument("--output_csv", type=str, default=None, help="Path to save results in CSV format (e.g., results.csv).")
+    output_group.add_argument("--output_plot", type=str, default=None, help="Path to save crosstalk plot as an image (e.g., plot.png). Plot is generated for sweep mode only.")
+    output_group.add_argument("--no_plot_display", action='store_true', help="Suppress interactive display of the plot. Plot will still be saved if --output_plot is specified.")
+
+
+    args = parser.parse_args()
+
+    if args.amplitude > 0:
+        error_console.print("Error: Signal amplitude (--amplitude) must be 0 dBFS or less.")
+        sys.exit(1)
+    if args.duration_per_step <= 0:
+        error_console.print("Error: Duration per step (--duration_per_step) must be positive.")
+        sys.exit(1)
+
+
+    # --- Device Selection and Validation ---
+    if args.device is None:
+        selected_device_idx = select_device()
+    else:
+        selected_device_idx = args.device
+        try:
+            devices = sd.query_devices() 
+            if not (0 <= selected_device_idx < len(devices)):
+                error_console.print(f"Error: Device ID {selected_device_idx} is invalid. Max ID is {len(devices)-1}.")
+                sys.exit(1)
+            device_info_check = sd.query_devices(selected_device_idx) 
+            if device_info_check['max_output_channels'] == 0:
+                error_console.print(f"Error: Device ID {selected_device_idx} ({device_info_check['name']}) has no output channels.")
+                sys.exit(1)
+            if device_info_check['max_input_channels'] == 0:
+                error_console.print(f"Error: Device ID {selected_device_idx} ({device_info_check['name']}) has no input channels.")
+                sys.exit(1)
+            console.print(f"Using specified device ID: {selected_device_idx} - {device_info_check['name']}")
+        except sd.PortAudioError as e:
+            error_console.print(f"Error querying audio devices: {e}")
+            sys.exit(1)
+        except Exception as e: 
+            error_console.print(f"An unexpected error occurred validating device ID {args.device}: {e}")
+            sys.exit(1)
+            
+    try:
+        device_info = sd.query_devices(selected_device_idx)
+    except sd.PortAudioError as e:
+        error_console.print(f"Error querying capabilities for device {selected_device_idx}: {e}")
+        sys.exit(1)
+
+    # --- Channel Conversion and Validation ---
+    output_channel_idx = channel_spec_to_index(args.output_channel, device_info['max_output_channels'], "output")
+    if output_channel_idx is None:
+        sys.exit(1)
+
+    if len(args.input_channels) < 2:
+        error_console.print("Error: At least two input channels must be specified (one reference, one or more for crosstalk measurement against).")
+        sys.exit(1)
+
+    input_channel_indices = []
+    for spec in args.input_channels:
+        idx = channel_spec_to_index(spec, device_info['max_input_channels'], "input")
+        if idx is None:
+            sys.exit(1)
+        if idx in input_channel_indices: 
+            error_console.print(f"Error: Input channel '{spec}' (resolved to index {idx}) is effectively a duplicate of a previously specified input channel. All resolved input channel indices must be unique.")
+            sys.exit(1)
+        input_channel_indices.append(idx)
+    
+    for i, undriven_idx_check in enumerate(input_channel_indices[1:]): 
+        if output_channel_idx == undriven_idx_check:
+            console.print(f"[yellow]Warning: Output channel ('{args.output_channel}' -> index {output_channel_idx}) is the same as undriven input channel '{args.input_channels[i+1]}' (index {undriven_idx_check}). This setup might not measure crosstalk correctly unless intended for a specific test configuration.[/yellow]")
+
+
+    # --- Frequency List Generation ---
+    frequencies_to_test = []
+    if args.sweep:
+        if args.start_freq <= 0 or args.end_freq <= 0:
+            error_console.print("Error: Sweep frequencies (--start_freq, --end_freq) must be positive.")
+            sys.exit(1)
+        if args.start_freq >= args.end_freq:
+            error_console.print("Error: Start frequency must be less than end frequency for sweep mode.")
+            sys.exit(1)
+        if args.points_per_octave <= 0:
+            error_console.print("Error: Points per octave (--points_per_octave) must be positive.")
+            sys.exit(1)
+        
+        current_freq = args.start_freq
+        while current_freq <= args.end_freq * (1 + 1e-9): 
+            frequencies_to_test.append(current_freq)
+            octave_multiplier = 2**(1/args.points_per_octave)
+            next_freq = current_freq * octave_multiplier
+            
+            if next_freq <= current_freq : 
+                if len(frequencies_to_test) == 1 or frequencies_to_test[-1] < args.end_freq : 
+                     if args.end_freq not in frequencies_to_test and args.end_freq > frequencies_to_test[-1]:
+                          frequencies_to_test.append(args.end_freq) 
+                break 
+            if len(frequencies_to_test) >= 500 : 
+                error_console.print(f"Warning: More than 500 frequency points generated for sweep, stopping. Adjust PPO or range.")
+                if args.end_freq not in frequencies_to_test and args.end_freq > frequencies_to_test[-1]: 
+                     if len(frequencies_to_test) < 501: frequencies_to_test.append(args.end_freq) 
+                break
+            current_freq = next_freq
+        
+        if not frequencies_to_test: 
+             error_console.print(f"Error: No frequencies generated for sweep from {args.start_freq} to {args.end_freq} with PPO {args.points_per_octave}.")
+             sys.exit(1)
+    else: 
+        if args.frequency <=0:
+            error_console.print("Error: Single test frequency (--frequency) must be positive.")
+            sys.exit(1)
+        frequencies_to_test.append(args.frequency)
+
+    console.print(f"\n[cyan]Device Configuration:[/cyan]")
+    console.print(f"  Playback/Record Device: {device_info['name']} (ID: {selected_device_idx}, Device SR: {device_info['default_samplerate']} Hz)")
+    console.print(f"  Script Using Sample Rate: {args.sample_rate} Hz")
+    console.print(f"  Test Signal Output Channel: '{args.output_channel}' (Device Index: {output_channel_idx})")
+    console.print(f"  Input Channels (Recorded): {args.input_channels} (Device Indices: {input_channel_indices})")
+    console.print(f"    Reference Input Channel (for driven signal level): '{args.input_channels[0]}' (Device Index: {input_channel_indices[0]})")
+    
+    console.print(f"\n[cyan]Test Parameters:[/cyan]")
+    console.print(f"  Mode: {'Sweep' if args.sweep else 'Single Frequency'}")
+    console.print(f"  Frequencies: " + ", ".join([f"{f:.2f}" for f in frequencies_to_test]) + " Hz")
+    console.print(f"  Signal Amplitude: {args.amplitude} dBFS")
+    console.print(f"  Duration per Step: {args.duration_per_step} s")
+    console.print(f"  FFT Window: {args.window}")
+
+    all_results_data = [] 
+
+    console.print(f"\n[green]Starting crosstalk analysis...[/green]")
+    for freq_hz in frequencies_to_test:
+        console.print(f"  Testing frequency: {freq_hz:.2f} Hz...")
+        
+        signal = generate_sine_wave(freq_hz, args.amplitude, args.duration_per_step, args.sample_rate)
+        
+        recorded_data = play_and_record_multi_ch(signal, args.sample_rate, 
+                                                 selected_device_idx, 
+                                                 output_channel_idx, input_channel_indices,
+                                                 args.duration_per_step, device_info) 
+        
+        freq_result_row = {'freq_hz': freq_hz, 'ref_amp_dbfs': np.nan} 
+        for i in range(1, len(input_channel_indices)): 
+            freq_result_row[f'undriven_ch_{i}_spec'] = args.input_channels[i] 
+            freq_result_row[f'undriven_ch_{i}_idx'] = input_channel_indices[i]
+            freq_result_row[f'undriven_ch_{i}_amp_dbfs'] = np.nan
+            freq_result_row[f'crosstalk_ch_{i}_db'] = np.nan
+
+        if recorded_data is None:
+            error_console.print(f"    Failed to play/record at {freq_hz:.2f} Hz. Results for this frequency will be NaN.")
+            all_results_data.append(freq_result_row) 
+            continue
+
+        analysis_results_per_input_ch = analyze_recorded_channels(recorded_data, args.sample_rate, freq_hz, args.window)
+
+        if not analysis_results_per_input_ch or len(analysis_results_per_input_ch) != len(input_channel_indices):
+            error_console.print(f"    Analysis failed or returned unexpected number of results at {freq_hz:.2f} Hz ({len(analysis_results_per_input_ch) if analysis_results_per_input_ch else 'None'} results for {len(input_channel_indices)} inputs). Results for this frequency will be NaN.")
+            all_results_data.append(freq_result_row) 
+            continue
+
+        amp_driven_input_linear = analysis_results_per_input_ch[0]['amplitude_linear']
+        ref_amp_dbfs = linear_to_dbfs(amp_driven_input_linear)
+        freq_result_row['ref_amp_dbfs'] = ref_amp_dbfs
+        
+        console.print(f"    Reference Channel ('{args.input_channels[0]}'): {ref_amp_dbfs:.2f} dBFS (Actual freq: {analysis_results_per_input_ch[0]['actual_freq']:.2f} Hz)")
+
+        for i in range(1, len(input_channel_indices)): 
+            undriven_ch_spec = args.input_channels[i]
+            amp_undriven_input_linear = analysis_results_per_input_ch[i]['amplitude_linear']
+            undriven_amp_dbfs = linear_to_dbfs(amp_undriven_input_linear)
+            
+            crosstalk_db = np.nan 
+            if amp_driven_input_linear > 1e-12 : 
+                if amp_undriven_input_linear > 1e-12:
+                    crosstalk_db = 20 * math.log10(amp_undriven_input_linear / amp_driven_input_linear)
+                else: 
+                    crosstalk_db = -np.inf 
+            elif amp_undriven_input_linear > 1e-12: 
+                 crosstalk_db = np.inf 
+            
+            console.print(f"    Undriven Channel ('{undriven_ch_spec}'): {undriven_amp_dbfs:.2f} dBFS (Actual freq: {analysis_results_per_input_ch[i]['actual_freq']:.2f} Hz). Crosstalk relative to '{args.input_channels[0]}': {crosstalk_db:.2f} dB")
+            
+            freq_result_row[f'undriven_ch_{i}_amp_dbfs'] = undriven_amp_dbfs
+            freq_result_row[f'crosstalk_ch_{i}_db'] = crosstalk_db
+        
+        all_results_data.append(freq_result_row)
+
+    # --- Display Results ---
+    if not all_results_data:
+        console.print("\n[yellow]No results to display (e.g., all frequencies failed or no frequencies tested).[/yellow]")
+        sys.exit(0)
+        
+    console.print(f"\n[bold underline cyan]Crosstalk Analysis Results[/bold underline cyan]")
+    results_table = Table(title=f"Crosstalk Measurement Summary (Output Ch: '{args.output_channel}')")
+    results_table.add_column("Freq (Hz)", style="magenta", justify="right", min_width=10)
+    results_table.add_column(f"Ref Ch ('{args.input_channels[0]}') Lvl (dBFS)", style="green", justify="right", min_width=22)
+
+    for i in range(1, len(input_channel_indices)):
+        undriven_ch_spec_header = args.input_channels[i] 
+        results_table.add_column(f"Ch '{undriven_ch_spec_header}' Lvl (dBFS)", style="yellow", justify="right", min_width=20)
+        results_table.add_column(f"Ch '{undriven_ch_spec_header}' Crosstalk (dB)", style="red", justify="right", min_width=22)
+
+    for res_row in all_results_data:
+        row_data_strings = [f"{res_row['freq_hz']:.2f}", f"{res_row['ref_amp_dbfs']:.2f}"]
+        for i in range(1, len(input_channel_indices)):
+            row_data_strings.append(f"{res_row.get(f'undriven_ch_{i}_amp_dbfs', np.nan):.2f}")
+            row_data_strings.append(f"{res_row.get(f'crosstalk_ch_{i}_db', np.nan):.2f}")
+        results_table.add_row(*row_data_strings)
+    
+    console.print(results_table)
+    console.print(f"\n[green]Crosstalk analysis complete. Reference channel for crosstalk calculation is '{args.input_channels[0]}'. Negative crosstalk values indicate isolation (signal on undriven channel is lower than on reference channel).[/green]")
+
+    # --- CSV Output ---
+    if args.output_csv:
+        try:
+            with open(args.output_csv, 'w', newline='') as csvfile:
+                # Define header based on the number of input channels
+                header = ['Frequency (Hz)', f'Ref Ch ({args.input_channels[0]}) Lvl (dBFS)']
+                for i in range(1, len(input_channel_indices)):
+                    undriven_ch_spec_header = args.input_channels[i]
+                    header.extend([
+                        f"Ch '{undriven_ch_spec_header}' Lvl (dBFS)",
+                        f"Ch '{undriven_ch_spec_header}' Crosstalk (dB)"
+                    ])
+                
+                writer = csv.writer(csvfile)
+                writer.writerow(header)
+                
+                for res_row in all_results_data:
+                    row_data = [f"{res_row['freq_hz']:.2f}", f"{res_row['ref_amp_dbfs']:.2f}"]
+                    for i in range(1, len(input_channel_indices)):
+                        row_data.append(f"{res_row.get(f'undriven_ch_{i}_amp_dbfs', np.nan):.2f}")
+                        row_data.append(f"{res_row.get(f'crosstalk_ch_{i}_db', np.nan):.2f}")
+                    writer.writerow(row_data)
+            console.print(f"\n[green]Results saved to CSV: {args.output_csv}[/green]")
+        except IOError as e:
+            error_console.print(f"\nError writing CSV file {args.output_csv}: {e}")
+        except Exception as e:
+            error_console.print(f"\nAn unexpected error occurred while writing CSV: {e}")
+
+    # --- Plotting ---
+    # Plot only if in sweep mode and there are results, and either output_plot is specified or interactive display is not suppressed.
+    can_plot = args.sweep and all_results_data and (args.output_plot or not args.no_plot_display)
+    
+    if can_plot:
+        console.print(f"\n[green]Generating plot...[/green]")
+        try:
+            frequencies = [r['freq_hz'] for r in all_results_data]
+            
+            plt.figure(figsize=(12, 7))
+            
+            for i in range(1, len(input_channel_indices)): # For each undriven channel
+                crosstalk_values = [r.get(f'crosstalk_ch_{i}_db', np.nan) for r in all_results_data]
+                # Filter out NaN for plotting if necessary, or let matplotlib handle them
+                # For simplicity, we plot them; matplotlib usually breaks lines at NaNs.
+                
+                # Check if there's any valid data to plot for this channel
+                if not all(np.isnan(crosstalk_values)):
+                    plt.plot(frequencies, crosstalk_values, marker='o', linestyle='-', label=f"Crosstalk to Ch '{args.input_channels[i]}'")
+                else:
+                    console.print(f"[yellow]Skipping plot for Ch '{args.input_channels[i]}' as all crosstalk values are NaN.[/yellow]")
+
+            plt.xscale('log')
+            plt.xlabel("Frequency (Hz)")
+            plt.ylabel("Crosstalk (dB)")
+            plt.title(f"Audio Crosstalk Analysis (Output Ch: '{args.output_channel}')")
+            plt.legend()
+            plt.grid(True, which="both", ls="-", alpha=0.5) # Grid for log scale
+            
+            # Add a horizontal line at -60dB as a common reference, if appropriate
+            # plt.axhline(-60, color='grey', linestyle='--', linewidth=0.8, label='-60 dB Reference')
+            
+            # Improve Y-axis limits if possible, e.g., based on data range
+            all_xtalk_values_flat = []
+            for i in range(1, len(input_channel_indices)):
+                all_xtalk_values_flat.extend([r.get(f'crosstalk_ch_{i}_db', np.nan) for r in all_results_data])
+            
+            valid_xtalk_values = [v for v in all_xtalk_values_flat if not np.isnan(v) and not np.isinf(v)]
+            if valid_xtalk_values:
+                min_val = min(valid_xtalk_values)
+                max_val = max(valid_xtalk_values)
+                y_margin = 10
+                # Ensure min_val is not positive infinity if all are -inf
+                if min_val == np.inf and max_val == np.inf: # All inf
+                     pass # Keep default limits
+                elif min_val == -np.inf and max_val == -np.inf: # all -inf
+                     plt.ylim(-120, -30) # Example range for very low crosstalk
+                else:
+                    y_min_limit = min(-30, math.floor(min_val / 10) * 10 - y_margin) 
+                    y_max_limit = max(0, math.ceil(max_val / 10) * 10 + y_margin)
+                    if y_max_limit > y_min_limit +5 : #Ensure sensible range
+                         plt.ylim(y_min_limit, y_max_limit)
+
+
+            if args.output_plot:
+                plt.savefig(args.output_plot)
+                console.print(f"Plot saved to: {args.output_plot}")
+            
+            if not args.no_plot_display:
+                console.print("Displaying plot window...")
+                plt.show()
+            
+        except ImportError:
+            error_console.print("\nMatplotlib is not installed. Cannot generate plot. Please install it: pip install matplotlib")
+        except Exception as e:
+            error_console.print(f"\nAn error occurred during plotting: {e}")
+    elif args.output_plot and not args.sweep:
+        console.print(f"\n[yellow]Plotting is enabled via --output_plot but only supported for sweep mode. No plot generated.[/yellow]")
+    elif args.output_plot and not all_results_data:
+         console.print(f"\n[yellow]Plotting is enabled via --output_plot but there are no results to plot. No plot generated.[/yellow]")
+
+
+if __name__ == '__main__':
+    main()

--- a/audio_crosstalk_analyzer/test_audio_crosstalk_analyzer.py
+++ b/audio_crosstalk_analyzer/test_audio_crosstalk_analyzer.py
@@ -1,0 +1,222 @@
+import unittest
+import numpy as np
+import math
+import sys
+
+# Attempt to import functions from the main script.
+# This path might need adjustment based on how tests are run (e.g., relative import if it's a package)
+try:
+    from audio_crosstalk_analyzer.audio_crosstalk_analyzer import (
+        generate_sine_wave,
+        _find_peak_amplitude_in_band,
+        analyze_recorded_channels,
+        channel_spec_to_index,
+        dbfs_to_linear, # For test_generate_sine_wave
+        linear_to_dbfs # For test_crosstalk_calculation_logic
+    )
+except ImportError:
+    # Fallback for running directly from the directory, assuming audio_crosstalk_analyzer.py is in the same dir or PYTHONPATH is set
+    # This is less ideal but common for simpler project structures.
+    # For proper package structure, the above import should work.
+    # If this script is in audio_crosstalk_analyzer/ and main script is also there,
+    # then from .audio_crosstalk_analyzer import ... would be typical if audio_crosstalk_analyzer is a package.
+    # If running tests from parent of audio_crosstalk_analyzer, then the original try should work.
+    # Let's assume for now the original try is the target for a structured project.
+    # Adding a simple path modification for local testing if needed:
+    # import os
+    # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) # Add parent dir
+    # from audio_crosstalk_analyzer.audio_crosstalk_analyzer import ...
+    # This is complex to get right without knowing execution context.
+    # For now, let the original try block handle it.
+    # If it fails, the tests won't run, which is an indicator of import issues.
+    print("Error: Could not import functions from audio_crosstalk_analyzer.audio_crosstalk_analyzer. Ensure PYTHONPATH is set correctly or adjust import paths.", file=sys.stderr)
+    # Re-raising the error to make it clear
+    raise
+
+class TestAudioCrosstalkAnalyzer(unittest.TestCase):
+
+    def setUp(self):
+        self.sample_rate = 48000
+        self.duration = 1.0
+        self.N = int(self.sample_rate * self.duration)
+        self.t = np.linspace(0, self.duration, self.N, endpoint=False)
+
+    def test_generate_sine_wave(self):
+        freq = 1000.0
+        amp_dbfs = -6.0
+        expected_amp_linear = dbfs_to_linear(amp_dbfs) # Approx 0.501
+
+        signal = generate_sine_wave(freq, amp_dbfs, self.duration, self.sample_rate)
+
+        self.assertEqual(len(signal), self.N, "Signal length incorrect")
+        # Check peak amplitude (can be slightly less than expected_amp_linear due to discrete time points)
+        self.assertAlmostEqual(np.max(np.abs(signal)), expected_amp_linear, delta=0.01, msg="Signal peak amplitude incorrect")
+
+        # FFT check
+        fft_result = np.fft.rfft(signal * np.hanning(self.N)) # Apply window
+        fft_freqs = np.fft.rfftfreq(self.N, d=1/self.sample_rate)
+        peak_idx = np.argmax(np.abs(fft_result))
+        detected_freq = fft_freqs[peak_idx]
+        self.assertAlmostEqual(detected_freq, freq, delta=1.0, msg="Dominant frequency in generated signal is incorrect")
+
+    def test_find_peak_amplitude_in_band(self):
+        fft_frequencies = np.array([0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+        fft_magnitudes = np.array([0.1, 0.5, 1.0, 0.8, 0.6, 0.4, 0.2]) # Peak at 20Hz, amplitude 1.0
+
+        # Test 1: Peak well within band
+        target_freq = 20.0
+        search_half_width = 5.0 # Band [15, 25]
+        act_freq, amp = _find_peak_amplitude_in_band(fft_magnitudes, fft_frequencies, target_freq, search_half_width)
+        self.assertEqual(act_freq, 20.0)
+        self.assertEqual(amp, 1.0)
+
+        # Test 2: Peak at edge of band (lower edge search)
+        target_freq = 17.5 # Searching around 17.5, band [12.5, 22.5]
+        act_freq, amp = _find_peak_amplitude_in_band(fft_magnitudes, fft_frequencies, target_freq, search_half_width)
+        self.assertEqual(act_freq, 20.0) # Still finds 20Hz as peak
+        self.assertEqual(amp, 1.0)
+
+        # Test 3: No peak in band
+        target_freq = 100.0
+        search_half_width = 5.0 # Band [95, 105]
+        act_freq, amp = _find_peak_amplitude_in_band(fft_magnitudes, fft_frequencies, target_freq, search_half_width)
+        self.assertEqual(act_freq, 100.0) # Returns nominal target_freq
+        self.assertEqual(amp, 0.0)     # Returns 0 amplitude
+
+        # Test 4: Exact frequency matching, narrow band
+        target_freq = 30.0
+        search_half_width = 1.0 # Band [29, 31]
+        act_freq, amp = _find_peak_amplitude_in_band(fft_magnitudes, fft_frequencies, target_freq, search_half_width)
+        self.assertEqual(act_freq, 30.0)
+        self.assertEqual(amp, 0.8)
+        
+        # Test 5: Empty FFT data (should not happen in practice if analyze_recorded_channels guards N > 0)
+        empty_freqs = np.array([])
+        empty_mags = np.array([])
+        act_freq, amp = _find_peak_amplitude_in_band(empty_mags, empty_freqs, 20.0, 5.0)
+        self.assertEqual(act_freq, 20.0) # Returns nominal target_freq
+        self.assertEqual(amp, 0.0)     # Returns 0 amplitude
+
+
+    def test_analyze_recorded_channels(self):
+        freq = 1000.0
+        amp_ch0_lin = 0.5
+        amp_ch1_lin = 0.05
+
+        ch0_signal = amp_ch0_lin * np.sin(2 * np.pi * freq * self.t)
+        ch1_signal = amp_ch1_lin * np.sin(2 * np.pi * freq * self.t)
+        
+        # Add a tiny bit of noise to avoid pure zeros if signal is zero
+        ch0_signal += np.random.normal(0, 1e-9, self.N)
+        ch1_signal += np.random.normal(0, 1e-9, self.N)
+
+        recorded_data = np.array([ch0_signal, ch1_signal]).T # Shape (N, 2)
+        window_name = 'hann'
+
+        analysis_results = analyze_recorded_channels(recorded_data, self.sample_rate, freq, window_name)
+
+        self.assertEqual(len(analysis_results), 2, "Analyze_recorded_channels did not return results for 2 channels")
+        
+        # Channel 0
+        self.assertAlmostEqual(analysis_results[0]['amplitude_linear'], amp_ch0_lin, delta=0.02, msg="Ch0 amplitude mismatch")
+        self.assertAlmostEqual(analysis_results[0]['actual_freq'], freq, delta=1.0, msg="Ch0 frequency mismatch")
+        
+        # Channel 1
+        self.assertAlmostEqual(analysis_results[1]['amplitude_linear'], amp_ch1_lin, delta=0.02, msg="Ch1 amplitude mismatch")
+        self.assertAlmostEqual(analysis_results[1]['actual_freq'], freq, delta=1.0, msg="Ch1 frequency mismatch")
+
+    def test_analyze_recorded_channels_empty_input(self):
+        empty_data = np.array([]).reshape(0,2) # 0 samples, 2 channels
+        results = analyze_recorded_channels(empty_data, self.sample_rate, 1000.0, 'hann')
+        self.assertEqual(len(results), 2)
+        for res in results:
+            self.assertEqual(res['amplitude_linear'], 0.0)
+
+        none_data = None
+        results_none = analyze_recorded_channels(none_data, self.sample_rate, 1000.0, 'hann')
+        self.assertEqual(len(results_none), 0)
+
+
+    def test_crosstalk_calculation_logic(self):
+        # Case 1: Standard crosstalk
+        amp_driven_linear = 0.5
+        amp_undriven_linear = 0.005
+        expected_crosstalk_db = 20 * math.log10(amp_undriven_linear / amp_driven_linear) # Should be -40 dB
+        
+        # Simulate what happens in main loop
+        # Here we directly test the formula as it appears in main, not by calling main()
+        calculated_crosstalk_db = np.nan
+        if amp_driven_linear > 1e-12:
+            if amp_undriven_linear > 1e-12:
+                calculated_crosstalk_db = 20 * math.log10(amp_undriven_linear / amp_driven_linear)
+            else:
+                calculated_crosstalk_db = -np.inf
+        elif amp_undriven_linear > 1e-12: # driven is zero, undriven is not
+            calculated_crosstalk_db = np.inf
+        
+        self.assertAlmostEqual(calculated_crosstalk_db, expected_crosstalk_db)
+
+        # Case 2: Undriven is zero (or very low)
+        amp_undriven_linear_zero = 1e-15 
+        expected_crosstalk_db_zero_undriven = -np.inf
+        
+        calculated_crosstalk_db_zero_undriven = np.nan
+        if amp_driven_linear > 1e-12:
+            if amp_undriven_linear_zero > 1e-12: # This will be false
+                calculated_crosstalk_db_zero_undriven = 20 * math.log10(amp_undriven_linear_zero / amp_driven_linear)
+            else:
+                calculated_crosstalk_db_zero_undriven = -np.inf
+        elif amp_undriven_linear_zero > 1e-12:
+             calculated_crosstalk_db_zero_undriven = np.inf
+        self.assertEqual(calculated_crosstalk_db_zero_undriven, expected_crosstalk_db_zero_undriven)
+
+        # Case 3: Driven is zero (or very low), undriven has signal
+        amp_driven_linear_zero = 1e-15
+        amp_undriven_linear_signal = 0.01
+        expected_crosstalk_db_zero_driven = np.inf
+        
+        calculated_crosstalk_db_zero_driven = np.nan
+        if amp_driven_linear_zero > 1e-12: # This will be false
+            # ...
+            pass
+        elif amp_undriven_linear_signal > 1e-12:
+            calculated_crosstalk_db_zero_driven = np.inf
+        self.assertEqual(calculated_crosstalk_db_zero_driven, expected_crosstalk_db_zero_driven)
+
+        # Case 4: Both driven and undriven are zero (or very low)
+        amp_driven_both_zero = 1e-15
+        amp_undriven_both_zero = 1e-14
+        expected_crosstalk_db_both_zero = np.nan # Remains NaN as per logic: driven <= 1e-12, and undriven <= 1e-12
+        
+        calculated_crosstalk_db_both_zero = np.nan
+        if amp_driven_both_zero > 1e-12:
+            pass
+        elif amp_undriven_both_zero > 1e-12:
+            calculated_crosstalk_db_both_zero = np.inf
+        # else: it remains np.nan
+        self.assertTrue(np.isnan(calculated_crosstalk_db_both_zero))
+
+
+    def test_channel_spec_to_index(self):
+        # Assuming a device with 2 channels for L/R tests
+        self.assertEqual(channel_spec_to_index('L', device_channels=2, channel_type="output"), 0)
+        self.assertEqual(channel_spec_to_index('R', device_channels=2, channel_type="output"), 1)
+        
+        # Numeric strings (0-based)
+        self.assertEqual(channel_spec_to_index('0', device_channels=2, channel_type="input"), 0)
+        self.assertEqual(channel_spec_to_index('1', device_channels=2, channel_type="input"), 1)
+        
+        # Test with more channels
+        self.assertEqual(channel_spec_to_index('2', device_channels=4, channel_type="input"), 2)
+        self.assertEqual(channel_spec_to_index(2, device_channels=4, channel_type="input"), 2) # Integer input
+
+        # Invalid specifiers
+        self.assertIsNone(channel_spec_to_index('X', device_channels=2, channel_type="input")) # Invalid string
+        self.assertIsNone(channel_spec_to_index('2', device_channels=2, channel_type="input")) # Out of bounds (0, 1 are valid)
+        self.assertIsNone(channel_spec_to_index('-1', device_channels=2, channel_type="input"))# Out of bounds
+        self.assertIsNone(channel_spec_to_index('R', device_channels=1, channel_type="input")) # 'R' not valid for 1-channel device
+        self.assertEqual(channel_spec_to_index('L', device_channels=1, channel_type="input"), 0) # 'L' is valid for 1-channel device
+
+if __name__ == '__main__':
+    # This allows running the tests directly from this file
+    unittest.main()


### PR DESCRIPTION
Implements a new capability, `audio_crosstalk_analyzer`, designed to measure audio crosstalk between channels.

Features:
- Supports both single frequency and frequency sweep modes for testing.
- You can configure test signal amplitude, output channel, and multiple input channels (first input channel is used as reference).
- Calculates crosstalk in dB by comparing the signal level on undriven input channels to the reference input channel.
- Provides output in a formatted table to the console using Rich.
- Optional CSV export of results.
- Optional plot generation of crosstalk vs. frequency using Matplotlib.
- Comprehensive CLI options for controlling test parameters and outputs.
- Includes unit tests for core data processing and utility functions.
- Detailed README for this capability with usage instructions and examples.
- Main project README updated to include this new capability.

This capability allows you to assess the isolation between audio channels in your hardware setups or devices under test.